### PR TITLE
FIX: add cd command in Install to fix pip error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 #### 1) Install GPTerminator
 ```zsh
 git clone https://github.com/AineeJames/ChatGPTerminator
+cd ChatGPTerminator
 pip install .
 ```
 or


### PR DESCRIPTION
fix: cd command missed in Install doc which will cause pip install error output:

> ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
