### PR TITLE
add code theme configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center">
 <img src="./imgs/panel_output.png" width="600" />
 </p>
-<p align="center">GPTerminator provides a convenient way to interact with OpenAI's chat completion and image generation API's using your command line interface.</p>
+<p align="center">GPTerminator provides a convenient way to interact with OpenAI's chat completion and image generation APIs using your command line interface.</p>
 <p align="center">
 <img src="https://img.shields.io/github/last-commit/AineeJames/ChatGPTerminator?style=for-the-badge&logo=github&color=7dc4e4&logoColor=D9E0EE&labelColor=302D41" />
 <img src="https://img.shields.io/github/stars/AineeJames/ChatGPTerminator?style=for-the-badge&logo=apachespark&color=eed49f&logoColor=D9E0EE&labelColor=302D41" />
@@ -10,11 +10,11 @@
 
 ## Features :sparkles:
 
-- :mag: Chat completion 
-- :floppy_disk: Save and load chat sessions 
-- :bar_chart: File analysis 
-- :art: Image generation with Dalle 
-- :clipboard: Easy code and text copying using 
+- :mag: Chat completion
+- :floppy_disk: Save and load chat sessions
+- :bar_chart: File analysis
+- :art: Image generation with Dalle
+- :clipboard: Easy code and text copying using
 - :repeat: Regeneration of responses
 
 ## Getting Started & Installation :rocket:
@@ -22,38 +22,53 @@
 ### To use this terminal interface, follow these steps:
 
 #### 1) Install GPTerminator
-```zsh
+
+```shell
 git clone https://github.com/AineeJames/ChatGPTerminator
 cd ChatGPTerminator
 pip install .
 ```
+
 or
-```zsh
+
+```shell
 pip install gpterminator
 ```
-#### 2) Set the OPENAI_API_KEY env variable (you may want this in your .rc file):
-```zsh
-export OPENAI_API_KEY=PUT_API_KEY_HERE
+
+#### 2) Set the OPENAI_API_KEY env variable (you may want this in your shell's `.rc` file):
+
+```shell
+export OPENAI_API_KEY=<YOUR_API_KEY>
 ```
+
 #### 3) Run the following command to start the ChatGPT terminal interface:
-```zsh
+
+```shell
 gpterm
 ```
+
 #### 4) You can now start chatting. Type a message and press Enter to get a response.
+
 #### 5) Type `!help` for a list of commands to use
 
 ## Running with podman/docker (optional) :package:
+
 #### Build the image and provide the `APIKEY`
+
 ```bash
-podman build \ 
-	--build-arg APIKEY=$(echo $OPENAI_API_KEY) \ 
+podman build \
+	--build-arg APIKEY=$(echo $OPENAI_API_KEY) \
 	-t gpterm .
 ```
-#### Run gpterm in the container
+
+#### Run `gpterm` in the container
+
 ```bash
-podman run -it --rm --name gpterm gpterm 
+podman run -it --rm --name gpterm gpterm
 ```
+
 #### Set an alias for easy access
+
 ```bash
 echo "alias gpterm='podman run -it --rm --name gpterm gpterm'" >> ~/.bashrc
 ```
@@ -61,54 +76,56 @@ echo "alias gpterm='podman run -it --rm --name gpterm gpterm'" >> ~/.bashrc
 ## Commands :exclamation:
 
 - Power up you chat experience with commands!
-- By typing `!help` you can view all the possible commands along with a short desctiption.
+- By typing `!help` you can view all the possible commands along with a short description.
 - Please check out the [wiki](https://github.com/AineeJames/ChatGPTerminator/wiki/Commands) for more detailed help with commands!
 
 ## Configuration :gear:
 
-The config.ini directory resides in different locations dependent on your OS. In order to find the path, run GPTerminator and then type `!pconf`.
+The `config.ini` configuration resides in different locations depending on your OS. In order to find the path, run `gpterm` and then enter `!pconf`.
 
-GPTerminator is configurable and can support multiple configurations. Add the following to your config.ini:
+GPTerminator is configurable and can support multiple configurations. Add the following to your `config.ini`:
 
-   ```ini
-   [CONFIG_TEMPLATE]
-   ModelName = 
-   SystemMessage = 
-   Temperature =
-   PresencePenalty = 
-   FrequencyPenalty = 
-   CommandInitiator = 
-   SavePath = 
-   ```
+```ini
+[CONFIG_TEMPLATE]
+ModelName =
+SystemMessage =
+Temperature =
+PresencePenalty =
+FrequencyPenalty =
+CommandInitiator =
+SavePath =
+CodeTheme =
+```
 
-- **ModelName:** this is the model used when chatting
-- **Temperature** = between 0 and 2
-- **PresencePenalty** = between -2 and 2
-- **FrequencyPenalty** = between -2 and 2
-- **SystemMessage:** this is the starting system message sent to the API
-- **CommandInitiator:** this can be set to change the default !<cmd> structure
-- **SavePath:** this changes the location of the save path when loading/saving
+| Setting              | Description                                                    | Default                                        |
+| -------------------- | -------------------------------------------------------------- | ---------------------------------------------- |
+| **ModelName**        | this is the model used when chatting                           | `gpt-3.5-turbo`                                |
+| **Temperature**      | between 0 and 2                                                | `1`                                            |
+| **PresencePenalty**  | between -2 and 2                                               | `0`                                            |
+| **FrequencyPenalty** | between -2 and 2                                               | `0`                                            |
+| **SystemMessage**    | this is the starting system message sent to the API            | You are a helpful assistant named GPTerminator |
+| **CommandInitiator** | this can be set to change the default `!` structure            | `!`                                            |
+| **SavePath**         | this changes the location of the save path when loading/saving | (default save path)                            |
+| **CodeTheme**        | this changes the Pygments theme of code blocks                 | `monokai`                                      |
 
-_Note_: More details on some settings can be found [here](https://platform.openai.com/docs/api-reference/chat/create)
+> **Note**
+> More details on some settings can be found [here](https://platform.openai.com/docs/api-reference/chat/create)
 
-After saving the config file, run: `gpterm`
-Then, type !setconf and select which config you wish to use, you can also run the !pconf commang to view the current config details.
+> **Note** If you change the `CommandInitiator`, you will now type `<new-command>` to execute commands...
 
-_Note_: If you change the CommandInitiator, you will now type <CommandInitiator><cmd> to execute commands...
-
+After saving the config file, run `gpterm`, then enter `!setconf` and select which config you wish to use. You can also run the `!pconf` command to view the current config details.
 
 ## Contributing :raised_hands:
 
 ### Current Contributors:
 
-
 <a href="https://github.com/AineeJames/ChatGPTerminator/graphs/contributors">
 <img src="https://contrib.rocks/image?repo=AineeJames/ChatGPTerminator" />
 </a>
 
-
 We welcome contributions to this project. If you find a bug, have a feature request, or want to contribute code, please open an issue or submit a pull request.
 
-## Disclaimer :warning: 
+## Disclaimer :warning:
 
-This program uses the openai API to chat and generate images using dalle. It is a good idea to put a usage cap on your billing, just in case something goes wrong!
+> **Warning**
+> This program uses the OpenAI API to chat and generate images using DALL·E. It is a good idea to put a usage cap on your billing, just in case something goes wrong!

--- a/gpterminator/GPTerminator.py
+++ b/gpterminator/GPTerminator.py
@@ -1,22 +1,24 @@
+import configparser
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import climage
 import openai
-from openai import error
+import pyperclip
+import requests
 import tiktoken
+from openai import error
+from prompt_toolkit import prompt
+from rich.columns import Columns
 from rich.console import Console
+from rich.live import Live
 from rich.markdown import Markdown
 from rich.panel import Panel
-from rich.live import Live
 from rich.syntax import Syntax
-from rich.columns import Columns
-import os
-import json
-import sys
-import configparser
-from prompt_toolkit import prompt
-from pathlib import Path
-import pyperclip
-import time
-import requests
-import climage
+
 
 class GPTerminator:
     def __init__(self):
@@ -70,6 +72,7 @@ class GPTerminator:
         self.temperature = config[self.config_selected]["Temperature"]
         self.presence_penalty = config[self.config_selected]["PresencePenalty"]
         self.frequency_penalty = config[self.config_selected]["FrequencyPenalty"]
+        self.code_theme = config[self.config_selected]["CodeTheme"]
 
     def printError(self, msg):
         self.console.print(Panel(f"[bold red]ERROR: [/]{msg}", border_style="red"))
@@ -112,7 +115,12 @@ class GPTerminator:
                     choice_list = []
                     for num, code_block in enumerate(code_block_list):
                         code_block = Syntax(code_block, lexer)
-                        choice = Panel(code_block, title=f"[bright_black]Option[/] [red]{num + 1}[/]", border_style="bright_black", style="bold")
+                        choice = Panel(
+                            code_block,
+                            title=f"[bright_black]Option[/] [red]{num + 1}[/]",
+                            border_style="bright_black",
+                            style="bold",
+                        )
                         choice_list.append(choice)
                     self.console.print(Columns(choice_list))
                     while True:
@@ -150,9 +158,7 @@ class GPTerminator:
         for idx, file_name in enumerate(os.listdir(f"{self.save_path}")):
             file_str = file_name.split(".")[0]
             file_dict[idx + 1] = file_str
-            self.console.print(
-                f"[bold bright_black]({idx + 1}) > [/][red]{file_str}[/]"
-            )
+            self.console.print(f"[bold bright_black]({idx + 1}) > [/][red]{file_str}[/]")
         if len(file_dict) == 0:
             self.printError("you have no saved chats")
             return
@@ -166,9 +172,7 @@ class GPTerminator:
                 break
             else:
                 self.printError(f"{selection} is not a valid selection")
-        with open(
-            Path(f"{self.save_path}") / f"{file_dict[int(selection)]}.json", "r"
-        ) as f:
+        with open(Path(f"{self.save_path}") / f"{file_dict[int(selection)]}.json", "r") as f:
             save = json.load(f)
         self.prompt_count = 0
         self.msg_hist = save
@@ -186,7 +190,7 @@ class GPTerminator:
                 num_tokens = len(encoding.encode(msg["content"]))
                 subtitle_str = f"[bright_black]Tokens:[/] [bold red]{num_tokens}[/]"
                 md = Panel(
-                    Markdown(msg["content"]),
+                    Markdown(msg["content"], self.code_theme),
                     border_style="bright_black",
                     title="[bright_black]Assistant[/]",
                     title_align="left",
@@ -206,9 +210,7 @@ class GPTerminator:
         for section in config:
             if str(section) != "DEFAULT" and str(section) != "SELECTED_CONFIG":
                 config_dict[config_num] = str(section)
-                self.console.print(
-                    f"[bright_black]({config_num}) > [/][red]{str(section)}[/]"
-                )
+                self.console.print(f"[bright_black]({config_num}) > [/][red]{str(section)}[/]")
                 config_num += 1
         while True:
             self.console.print(
@@ -245,9 +247,7 @@ class GPTerminator:
                 break
             else:
                 self.printError("the image prompt should be at least 10 characters")
-        with self.console.status(
-            "", spinner="bouncingBar", spinner_style="bold red"
-        ) as status:
+        with self.console.status("", spinner="bouncingBar", spinner_style="bold red") as status:
             status.update(status="[bright_black]Generating image...[/]")
             img_response = openai.Image.create(prompt=user_in, n=1, size="1024x1024")
             image_url = img_response["data"][0]["url"]
@@ -267,7 +267,7 @@ class GPTerminator:
             )
             user_in = prompt().strip()
             if os.path.exists(user_in):
-                with open(user_in, 'r') as file:
+                with open(user_in, "r") as file:
                     file_content = file.read()
                 break
             else:
@@ -286,10 +286,6 @@ class GPTerminator:
 
         msg = f"{user_prmt}: '{file_content}'"
         self.getResponse(msg)
-
-            
-
-
 
     def queryUser(self):
         self.console.print(
@@ -314,9 +310,7 @@ class GPTerminator:
                         self.prompt_count -= 1
                         return last_msg
                     else:
-                        self.printError(
-                            "can't regenenerate, there is no previous prompt"
-                        )
+                        self.printError("can't regenenerate, there is no previous prompt")
                 elif cmd == "save" or cmd == "s":
                     self.saveChat()
                 elif cmd == "ccpy" or cmd == "cc":
@@ -385,7 +379,7 @@ class GPTerminator:
         subtitle_str = f"[bright_black]Tokens:[/] [bold red]{0}[/] | "
         subtitle_str += f"[bright_black]Time Elapsed:[/][bold yellow] {0.0}s [/]"
         md = Panel(
-            Markdown(""),
+            Markdown("", self.code_theme),
             border_style="bright_black",
             title="[bright_black]Assistant[/]",
             title_align="left",
@@ -400,16 +394,16 @@ class GPTerminator:
                 collected_chunks.append(chunk)  # save the event response
                 chunk_message = chunk["choices"][0]["delta"]  # extract the message
                 collected_messages.append(chunk_message)  # save the message
-                full_reply_content = "".join(
-                    [m.get("content", "") for m in collected_messages]
-                )
+                full_reply_content = "".join([m.get("content", "") for m in collected_messages])
                 encoding = tiktoken.encoding_for_model(self.model)
                 num_tokens = len(encoding.encode(full_reply_content))
                 time_elapsed_s = time.time() - start_time
                 subtitle_str = f"[bright_black]Tokens:[/] [bold red]{num_tokens}[/] | "
-                subtitle_str += f"[bright_black]Time Elapsed:[/][bold yellow] {time_elapsed_s:.1f}s [/]"
+                subtitle_str += (
+                    f"[bright_black]Time Elapsed:[/][bold yellow] {time_elapsed_s:.1f}s [/]"
+                )
                 md = Panel(
-                    Markdown(full_reply_content),
+                    Markdown(full_reply_content, self.code_theme),
                     border_style="bright_black",
                     title="[bright_black]Assistant[/]",
                     title_align="left",
@@ -443,7 +437,6 @@ class GPTerminator:
         )
 
     def checkDirs(self):
-
         # get paths
         if "APPDATA" in os.environ:
             confighome = os.environ["APPDATA"]
@@ -454,7 +447,7 @@ class GPTerminator:
         configpath = os.path.join(confighome, "gpterminator")
         savespath = os.path.join(configpath, "saves")
 
-        #check if paths/files exist
+        # check if paths/files exist
         config_exists = os.path.exists(os.path.join(configpath, "config.ini"))
         configpath_exists = os.path.exists(configpath)
         saves_exist = os.path.exists(savespath)
@@ -477,10 +470,11 @@ class GPTerminator:
                 "SystemMessage": "You are a helpful assistant named GPTerminator.",
                 "CommandInitiator": "!",
                 "SavePath": f"{savespath}",
+                "CodeTheme": "monokai",
             }
             with open(full_config_path, "w") as configfile:
                 config.write(configfile)
-        
+
         if saves_exist == False:
             self.console.print(f"[bright_black]Initializing save path ({savespath})...[/]")
             os.mkdir(savespath)


### PR DESCRIPTION
- Adds functionality to change the theme of code blocks, via `codetheme` in `config.ini` 
   (see: [pygments.org/styles](https://pygments.org/styles/) — defaults to the original `monokai` style)
- Edited README appropriately (and fixed some typos/formatting)


### Examples:

#### `codetheme = github-dark`
<img width="722" alt="image" src="https://github.com/AineeJames/ChatGPTerminator/assets/43590347/06a6581b-b37c-43a1-850d-abbc2768da47">

#### `codetheme = one-dark`
<img width="719" alt="image" src="https://github.com/AineeJames/ChatGPTerminator/assets/43590347/9bf41b49-1efa-4464-9e4c-3625466fae34">

#### `codetheme = xcode`
<img width="720" alt="image" src="https://github.com/AineeJames/ChatGPTerminator/assets/43590347/e7609739-a027-40fa-8702-2fe6d428b93d">




